### PR TITLE
closed path for polygons

### DIFF
--- a/svg-to-wkt.js
+++ b/svg-to-wkt.js
@@ -316,7 +316,7 @@
 
       var parts = [];
       _.each(polys, function(poly) {
-        parts.push('(' + __pathPoints(poly).join() + ')');
+        parts.push('(' + __pathPoints(poly, true).join() + ')');
       });
 
       return 'POLYGON(' + parts.join() + ')';


### PR DESCRIPTION
I had an error converting polygon paths to WKT and noticed the closed parameter was missing for the __pathPoints call
